### PR TITLE
Simple pagination

### DIFF
--- a/app/components/Pagination/Pagination.tsx
+++ b/app/components/Pagination/Pagination.tsx
@@ -1,0 +1,35 @@
+import { Link } from "react-router-dom";
+
+interface PaginationProps {
+  totalPages: number;
+  currentPage: number;
+  basePath?: string;
+}
+
+const Pagination: React.FC<PaginationProps> = ({
+  basePath = "pages",
+  currentPage,
+  totalPages,
+}) => {
+  const previousPagePath =
+    currentPage > 1 ? `/${basePath}/${currentPage - 1}` : undefined;
+  const nextPagePath =
+    currentPage < totalPages ? `/${basePath}/${currentPage + 1}` : undefined;
+
+  return (
+    <div>
+      {previousPagePath && (
+        <Link to={previousPagePath} className="mr-2 hover:underline">
+          Previous
+        </Link>
+      )}
+      {nextPagePath && (
+        <Link to={nextPagePath} className="hover:underline">
+          Next
+        </Link>
+      )}
+    </div>
+  );
+};
+
+export default Pagination;

--- a/app/components/Pagination/index.ts
+++ b/app/components/Pagination/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Pagination";

--- a/app/lib/db/queries/storiesByPage.ts
+++ b/app/lib/db/queries/storiesByPage.ts
@@ -1,0 +1,29 @@
+import { db, StoryWithTopics } from "..";
+
+const STORIES_PER_PAGE = 5;
+
+export interface StoriesByPageData {
+  stories: StoryWithTopics[];
+  currentPage: number;
+  totalPages: number;
+}
+
+export const getStoriesByPage = async (
+  currentPage: number | undefined = 1,
+): Promise<StoriesByPageData> => {
+  const storiesCount = await db.story.count();
+  const totalPages = Math.ceil(storiesCount / STORIES_PER_PAGE);
+
+  const stories = await db.story.findMany({
+    orderBy: {
+      createdAt: "desc",
+    },
+    include: {
+      topics: true,
+    },
+    skip: (currentPage - 1) * STORIES_PER_PAGE,
+    take: STORIES_PER_PAGE,
+  });
+
+  return { stories, currentPage, totalPages };
+};

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,8 +1,12 @@
-import type { MetaFunction, LoaderFunction } from "remix";
-import { useRouteData } from "remix";
 import { Link } from "react-router-dom";
-import { db, StoryWithTopics } from "../lib/db";
+import type { LoaderFunction, MetaFunction } from "remix";
+import { useRouteData } from "remix";
+import Pagination from "../components/Pagination/Pagination";
 import StoryListItem from "../components/StoryListItem/StoryListItem";
+import {
+  getStoriesByPage,
+  StoriesByPageData,
+} from "../lib/db/queries/storiesByPage";
 
 export const meta: MetaFunction = () => {
   return {
@@ -13,25 +17,13 @@ export const meta: MetaFunction = () => {
 };
 
 export const loader: LoaderFunction = async () => {
-  const stories = await db.story.findMany({
-    orderBy: {
-      createdAt: "desc",
-    },
-    include: {
-      topics: true,
-    },
-    take: 2,
-  });
-
-  return { stories };
+  return await getStoriesByPage();
 };
 
-interface IndexRouteData {
-  stories: StoryWithTopics[];
-}
+interface IndexRouteData extends StoriesByPageData {}
 
 export default function Index() {
-  const { stories } = useRouteData<IndexRouteData>();
+  const { stories, currentPage, totalPages } = useRouteData<IndexRouteData>();
 
   return (
     <>
@@ -61,7 +53,9 @@ export default function Index() {
         ))}
       </ul>
 
-      <Link to="/pages/2">Next page</Link>
+      <div className="mt-4">
+        <Pagination currentPage={currentPage} totalPages={totalPages} />
+      </div>
     </>
   );
 }

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -20,6 +20,7 @@ export const loader: LoaderFunction = async () => {
     include: {
       topics: true,
     },
+    take: 2,
   });
 
   return { stories };
@@ -59,6 +60,8 @@ export default function Index() {
           </li>
         ))}
       </ul>
+
+      <Link to="/pages/2">Next page</Link>
     </>
   );
 }

--- a/app/routes/pages/$number.tsx
+++ b/app/routes/pages/$number.tsx
@@ -1,0 +1,51 @@
+import type { MetaFunction, LoaderFunction } from "remix";
+import { useRouteData } from "remix";
+import { Link } from "react-router-dom";
+import { db, StoryWithTopics } from "../../lib/db";
+import StoryListItem from "../../components/StoryListItem/StoryListItem";
+
+export const meta: MetaFunction = () => {
+  return {
+    title: "The Rodinia Report",
+    description:
+      "The Rodinia Report is a public curation of environmentally focused articles that helps individuals easily stay up to date on the most recent and most inspiring undertakings around the world.",
+  };
+};
+
+export const loader: LoaderFunction = async ({ params }) => {
+  const stories = await db.story.findMany({
+    orderBy: {
+      createdAt: "desc",
+    },
+    include: {
+      topics: true,
+    },
+    skip: (parseInt(params.number)-1) * 2,
+  });
+
+  return { stories, pageNumber: params.number };
+};
+
+interface IndexRouteData {
+  stories: StoryWithTopics[];
+  pageNumber: number;
+}
+
+export default function Index() {
+  const { stories, pageNumber } = useRouteData<IndexRouteData>();
+
+  const previousPagePath = pageNumber > 2 ? `/pages/${pageNumber-1}` : `/`;
+
+  return (
+    <>
+      <ul className="bg-alabaster-300 shadow-sm rounded-sm divide-y divide-alabaster mt-8">
+        {stories?.map((story) => (
+          <li key={story.sourceTitle}>
+            <StoryListItem story={story} />
+          </li>
+        ))}
+      </ul>
+      <Link to={previousPagePath}>Previous Page</Link>
+    </>
+  );
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -68,6 +68,90 @@ async function main() {
         sourcePaywalled: false,
         userId: "123", // How to grab this from FB?
       },
+      {
+        sourceTitle:
+          "Biden Administration to Restore Clean-Water Protections Ended by Trump",
+        sourceUrl:
+          "https://www.nytimes.com/2021/06/09/climate/biden-clean-water-wotus.html",
+        sourcePaywalled: true,
+        userId: "123", // How to grab this from FB?
+      },
+      {
+        sourceTitle:
+          "Collapse of Infrastructure Talks Puts Climate Action at Risk",
+        sourceUrl:
+          "https://www.nytimes.com/2021/06/09/climate/climate-congress-infrastructure.html",
+        sourcePaywalled: true,
+        userId: "123", // How to grab this from FB?
+      },
+      {
+        sourceTitle:
+          "Carbon Dioxide in Atmosphere Hits Record High Despite Pandemic Dip",
+        sourceUrl:
+          "https://www.nytimes.com/2021/06/07/climate/climate-change-emissions.html",
+        sourcePaywalled: true,
+        userId: "123", // How to grab this from FB?
+      },
+      {
+        sourceTitle: "The Keystone XL pipeline project has been terminated.",
+        sourceUrl:
+          "https://www.nytimes.com/2021/06/09/business/keystone-xl-pipeline-canceled.html",
+        sourcePaywalled: true,
+        userId: "123", // How to grab this from FB?
+      },
+      {
+        sourceTitle:
+          "G.M. agrees to tighter federal restrictions aimed at combating climate change.",
+        sourceUrl:
+          "https://www.nytimes.com/2021/06/09/us/politics/gm-biden-fuel-economy-rules.html",
+        sourcePaywalled: true,
+        userId: "123", // How to grab this from FB?
+      },
+      {
+        sourceTitle: "Scenes From the Western Drought",
+        sourceUrl:
+          "https://www.nytimes.com/interactive/2021/06/08/climate/western-drought.html",
+        sourcePaywalled: true,
+        userId: "123", // How to grab this from FB?
+      },
+      {
+        sourceTitle:
+          "Biden Aims to End Arctic Drilling. A Trump-Era Law Could Foil His Plans.",
+        sourceUrl:
+          "https://www.nytimes.com/2021/06/02/climate/ANWR-drilling-Biden.html",
+        sourcePaywalled: true,
+        userId: "123", // How to grab this from FB?
+      },
+      {
+        sourceTitle:
+          "Biden Suspends Drilling Leases in Arctic National Wildlife Refuge",
+        sourceUrl:
+          "https://www.nytimes.com/2021/06/01/climate/biden-drilling-arctic-national-wildlife-refuge.html",
+        sourcePaywalled: true,
+        userId: "123", // How to grab this from FB?
+      },
+      {
+        sourceTitle:
+          "Exxon Mobil Faces Off Against Activist Investors on Climate Change",
+        sourceUrl:
+          "https://www.nytimes.com/2021/05/25/business/exxon-mobil-climate-change.html",
+        sourcePaywalled: true,
+        userId: "123", // How to grab this from FB?
+      },
+      {
+        sourceTitle: "Floating igloos offer hope for threatened penguins",
+        sourceUrl:
+          "https://www.theweek.co.uk/951581/floating-igloos-offer-hope-penguins-climate-change",
+        sourcePaywalled: true,
+        userId: "123", // How to grab this from FB?
+      },
+      {
+        sourceTitle: "China to end import of world's rubbish",
+        sourceUrl:
+          "https://www.theweek.co.uk/108842/china-bans-import-worlds-rubbish",
+        sourcePaywalled: true,
+        userId: "123", // How to grab this from FB?
+      },
     ],
   });
 }


### PR DESCRIPTION
A take on paginated stories.

* Adds more story data to the seed file
* Adds `Next`/`Previous` links on relevant pages through `Pagination` component
* Adds a `getStoriesByPage` query helper to return relevant data for paginated stories

I'm open to refactoring and/or re-structuring anything!

Issue: #32 